### PR TITLE
setting geom_text

### DIFF
--- a/vignettes/links.Rmd
+++ b/vignettes/links.Rmd
@@ -77,7 +77,10 @@ df_potter <- checkSex(df_potter,
 
 
 ```{r echo=TRUE, fig.cap="Pedigree plot of the Potter dataset", fig.height=3, fig.width=4, message=FALSE, warning=FALSE}
-ggpedigree(potter)
+ggpedigree(potter, config=list(label_method = "geom_text",
+                               label_nudge_y = -.25)) +
+  labs(title = "Pedigree Plot of the Potter Dataset") +
+  theme(legend.position = "bottom")
 ```
 
 The pedigree plot provides a visual representation of the kinship structure in the dataset. Each node represents an individual, and the edges indicate familial relationships. 
@@ -140,8 +143,6 @@ df_cousin <- df_links %>%
 # Simulate Phenotypic Data
 
 To simulate phenotypic data, we need to create a data frame that includes the kinship information and the outcome variables. We will simulate two outcome variables (y1 and y2) for each cousin pair in the dataset. The `kinsim()` function from {discord} is used to generate the simulated data based on the specified variance structure.
-
-
 
 ```{r}
 set.seed(1234)


### PR DESCRIPTION
This pull request introduces enhancements to the pedigree plot in the Potter dataset and removes unnecessary blank lines in the code for simulating phenotypic data. The most important changes focus on improving the visual representation of the plot and tidying up the code formatting.

### Enhancements to the pedigree plot:

* [`vignettes/links.Rmd`](diffhunk://#diff-d9d8e45807c97d6b96557b882586ccf9146311722d87171af8f6cba313f1c0b8L80-R83): Updated the `ggpedigree` function to include a custom labeling method (`geom_text`), adjusted label positioning (`label_nudge_y = -.25`), added a plot title ("Pedigree Plot of the Potter Dataset"), and moved the legend to the bottom for better visualization.

### Code formatting improvements:

* [`vignettes/links.Rmd`](diffhunk://#diff-d9d8e45807c97d6b96557b882586ccf9146311722d87171af8f6cba313f1c0b8L144-L145): Removed unnecessary blank lines before the `kinsim()` function call to improve code readability.